### PR TITLE
Add support for handling multi-file artifacts

### DIFF
--- a/src/shelf/__init__.py
+++ b/src/shelf/__init__.py
@@ -7,5 +7,5 @@ except PackageNotFoundError:
     pass
 
 
+from .core import Shelf
 from .registry import deregister_type, lookup, register_type
-from .shelf import Shelf

--- a/src/shelf/util.py
+++ b/src/shelf/util.py
@@ -1,3 +1,5 @@
+import os
+
 from fsspec.utils import get_protocol, stringify_path
 
 
@@ -5,3 +7,7 @@ def is_fully_qualified(path: str) -> bool:
     path = stringify_path(path)
     protocol = get_protocol(path)
     return any(path.startswith(protocol + sep) for sep in ("::", "://"))
+
+
+def with_trailing_sep(path: str) -> str:
+    return path if path.endswith(os.sep) else path + os.sep

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
-from typing import Generator
+from pathlib import Path
+from typing import Any, Generator
 
 import pytest
+import yaml
 
-from shelf.registry import _registry
+import shelf.registry
+
+testdir = Path(__file__).parent
 
 
 @pytest.fixture(autouse=True)
@@ -11,4 +15,10 @@ def empty_registry() -> Generator[None, None, None]:
     try:
         yield
     finally:
-        _registry.clear()
+        shelf.registry._registry.clear()
+
+
+@pytest.fixture(scope="session")
+def fsconfig() -> dict[str, dict[str, Any]]:
+    with open(testdir / "shelfconfig.yaml", "r") as f:
+        return yaml.safe_load(f)

--- a/tests/shelfconfig.yaml
+++ b/tests/shelfconfig.yaml
@@ -1,0 +1,3 @@
+file:
+  storage:
+    auto_mkdir: true

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -28,3 +28,39 @@ def test_json_roundtrip(tmp_path: Path) -> None:
     data2 = s.get("myobj.json", dict)
 
     assert data == data2
+
+
+def test_multifile_artifact(tmp_path: Path, fsconfig: dict) -> None:
+    """
+    Test a dict artifact JSON roundtrip with the dict serialized into two different files.
+
+    No nested directories, only multiple filenames.
+    """
+
+    def json_dump(d: dict, tmpdir: str) -> tuple[str, ...]:
+        d1, d2 = {"a": d["a"]}, {"b": d["b"]}
+        fnames = []
+        for i, d in enumerate((d1, d2)):
+            fname = os.path.join(tmpdir, f"dump{i}.json")
+            fnames.append(fname)
+            with open(fname, "w") as f:
+                json.dump(d, f)
+        return tuple(fnames)
+
+    def json_load(fnames: tuple[str, str]) -> dict:
+        d: dict = {}
+        for fname in fnames:
+            with open(fname, "r") as f:
+                d |= json.load(f)
+        return d
+
+    shelf.register_type(dict, json_dump, json_load)
+
+    s = shelf.Shelf(prefix=tmp_path, fsconfig=fsconfig)
+
+    data = {"a": 1, "b": 2}
+
+    s.put(data, "myobj")
+    data2 = s.get("myobj", dict)
+
+    assert data == data2


### PR DESCRIPTION
Multifile artifacts can now be handled by passing a `tuple[str, ...]` to the deserializer interface.

The current solution is most likely a stopgap to a more comprehensive treatment with a single- vs. multi-file hint, derived either from type hints on the serde interface or via explicit specification.