### PR TITLE
Unify serde interface by introducing `Shelf.Context`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
        types_or: [ python, pyi ]
        args: [--ignore-missing-imports, --scripts-are-modules]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.11
+    rev: v0.1.14
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/README.md
+++ b/README.md
@@ -29,19 +29,18 @@ class MyModel:
         return 1.
 
 
-def save_to_disk(model: MyModel, tmpdir: str) -> str:
+def save_to_disk(model: MyModel, ctx: shelf.Context) -> None:
     """Dumps the model to the directory ``tmpdir`` using `pickle`."""
-    fname = os.path.join(tmpdir, "my-model.pkl")
-    with open(fname, "wb") as f:
-        pickle.dump(model, f)
-    return fname
+    fp = ctx.file("my-model.pkl", mode="wb")
+    pickle.dump(model, fp)
 
 
-def load_from_disk(fname: str) -> MyModel:
+def load_from_disk(ctx: shelf.Context) -> MyModel:
     """Reloads the previously pickled model."""
-    with open(fname, "rb") as f:
-        model: MyModel = pickle.load(f)
-        return model
+    fname, = ctx.filenames
+    fp = ctx.file(fname, mode="rb")
+    model: MyModel = pickle.load(fp)
+    return model
 
 
 shelf.register_type(MyModel, save_to_disk, load_from_disk)

--- a/src/shelf/__init__.py
+++ b/src/shelf/__init__.py
@@ -9,3 +9,4 @@ except PackageNotFoundError:
 
 from .core import Shelf
 from .registry import deregister_type, lookup, register_type
+from .types import Context

--- a/src/shelf/types.py
+++ b/src/shelf/types.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from os import PathLike
+from pathlib import Path
+from typing import IO, Any, Callable, Generic, Literal, TypeVar
+
+T = TypeVar("T")
+
+
+# TODO: Consider splitting these into ReadContext and WriteContext
+class Context:
+    def __init__(self, tmpdir: str | PathLike[str], filenames: list[str] | None = None):
+        self._tmpdir = Path(tmpdir)
+        self._fds: deque[IO] = deque()
+        self._filenames: list[str] = filenames or []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Unwind the file queue by closing
+        while self._fds:
+            file = self._fds.pop()
+            file.close()
+
+    @property
+    def files(self):
+        return self._fds
+
+    @property
+    def filenames(self):
+        return self._filenames
+
+    @property
+    def tmpdir(self):
+        return self._tmpdir
+
+    def directory(self, name: str) -> PathLike[str]:
+        return self.tmpdir / name
+
+    def file(self, name: str, **openkwargs: Any) -> IO:
+        # TODO: Assert name is not absolute
+        fp = self.tmpdir / name
+        desc = open(fp, **openkwargs)
+        self._fds.append(desc)
+        self._filenames.append(str(fp))
+        return desc
+
+
+@dataclass(frozen=True)
+class IOPair(Generic[T]):
+    serializer: Callable[[T, Context], None]
+    deserializer: Callable[[Context], T]
+
+
+@dataclass(frozen=True)
+class CacheOptions:
+    directory: PathLike[str]
+    type: Literal["blockcache", "filecache", "simplecache"] = "filecache"

--- a/src/shelf/util.py
+++ b/src/shelf/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import Any
 

--- a/src/shelf/util.py
+++ b/src/shelf/util.py
@@ -1,13 +1,39 @@
 import os
+from typing import Any
 
+from fsspec import AbstractFileSystem, filesystem
 from fsspec.utils import get_protocol, stringify_path
 
+from shelf.types import CacheOptions
 
-def is_fully_qualified(path: str) -> bool:
+
+def filesystem_from_uri(
+    uri: str,
+    cache_options: CacheOptions | None = None,
+    storage_options: dict[str, Any] | None = None,
+) -> AbstractFileSystem:
+    protocol = get_protocol(uri)
+    storage_options = storage_options or {}
+    if cache_options is not None:
+        protocol = cache_options.type
+        kwargs = {
+            "target_protocol": cache_options.type,
+            "target_options": storage_options,
+            "cache_storage": cache_options.directory,
+        }
+    else:
+        kwargs = storage_options
+
+    fs: AbstractFileSystem = filesystem(protocol, **kwargs)
+    return fs
+
+
+def is_fully_qualified(path: str | os.PathLike[str]) -> bool:
     path = stringify_path(path)
     protocol = get_protocol(path)
     return any(path.startswith(protocol + sep) for sep in ("::", "://"))
 
 
-def with_trailing_sep(path: str) -> str:
+def with_trailing_sep(path: str | os.PathLike[str]) -> str:
+    path = stringify_path(path)
     return path if path.endswith(os.sep) else path + os.sep

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,17 +6,17 @@ from shelf.registry import lookup, registry
 
 def test_registration() -> None:
     """Type registration tests."""
-    shelf.register_type(tuple, lambda t: "my-tuple.txt", lambda fp: tuple())
+    shelf.register_type(tuple, lambda t, ctx: None, lambda fp: tuple())
 
     assert tuple in registry
 
     with pytest.raises(RuntimeError, match="type .* already registered"):
-        shelf.register_type(tuple, lambda t: "my-type.txt", lambda fp: tuple())
+        shelf.register_type(tuple, lambda t, ctx: None, lambda fp: tuple())
 
-    def new_ser(t: tuple) -> str:
-        return "my-tuple.json"
+    def new_ser(t: tuple, ctx: shelf.Context) -> None:
+        pass
 
-    def new_deser(fp: str) -> tuple:
+    def new_deser(ctx: shelf.Context) -> tuple:
         return ("hello",)
 
     shelf.register_type(tuple, new_ser, new_deser, clobber=True)
@@ -30,7 +30,7 @@ def test_deregistration() -> None:
     class MyType:
         pass
 
-    shelf.register_type(MyType, lambda t: "my-type.txt", lambda fp: MyType())
+    shelf.register_type(MyType, lambda t, ctx: None, lambda fp: MyType())
     assert MyType in registry
     shelf.deregister_type(MyType)
     assert MyType not in registry

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -1,6 +1,7 @@
 import json
-import os
 from pathlib import Path
+
+from fsspec.implementations.local import LocalFileSystem
 
 import shelf
 
@@ -8,59 +9,60 @@ import shelf
 def test_json_roundtrip(tmp_path: Path) -> None:
     """Test a simple data artifact JSON roundtrip."""
 
-    def json_dump(d: dict, tmpdir: str) -> str:
-        fname = os.path.join(tmpdir, "dump.json")
-        with open(fname, "w") as f:
-            json.dump(d, f)
-        return fname
+    def json_dump(d: dict, ctx: shelf.Context) -> None:
+        fp = ctx.file("dump.json", mode="w")
+        json.dump(d, fp)
 
-    def json_load(fname: str) -> dict:
-        with open(fname, "r") as f:
-            return json.load(f)
+    def json_load(ctx: shelf.Context) -> dict:
+        (fname,) = ctx.filenames
+        fp = ctx.file(fname, mode="r")
+        return json.load(fp)
 
     shelf.register_type(dict, json_dump, json_load)
 
-    s = shelf.Shelf(prefix=tmp_path)
+    shlf = shelf.Shelf()
 
     data = {"a": 1, "b": 2}
 
-    s.put(data, "myobj.json")
-    data2 = s.get("myobj.json", dict)
+    rpath = f"file://{tmp_path}/myobj.json"
+
+    shlf.put(data, rpath)
+    fs = LocalFileSystem()
+    assert fs.exists(rpath)
+    assert fs.size(rpath) > 0
+    data2 = shlf.get(rpath, dict)
 
     assert data == data2
 
 
-def test_multifile_artifact(tmp_path: Path, fsconfig: dict) -> None:
+def test_multifile_artifact(tmp_path: Path) -> None:
     """
     Test a dict artifact JSON roundtrip with the dict serialized into two different files.
 
     No nested directories, only multiple filenames.
     """
 
-    def json_dump(d: dict, tmpdir: str) -> tuple[str, ...]:
+    def json_dump(d: dict, ctx: shelf.Context) -> None:
         d1, d2 = {"a": d["a"]}, {"b": d["b"]}
-        fnames = []
         for i, d in enumerate((d1, d2)):
-            fname = os.path.join(tmpdir, f"dump{i}.json")
-            fnames.append(fname)
-            with open(fname, "w") as f:
-                json.dump(d, f)
-        return tuple(fnames)
+            fp = ctx.file(f"dump{i}.json", mode="w")
+            json.dump(d, fp)
 
-    def json_load(fnames: tuple[str, str]) -> dict:
+    def json_load(ctx: shelf.Context) -> dict:
         d: dict = {}
-        for fname in fnames:
+        for fname in ctx.filenames:
             with open(fname, "r") as f:
                 d |= json.load(f)
         return d
 
     shelf.register_type(dict, json_dump, json_load)
 
-    s = shelf.Shelf(prefix=tmp_path, fsconfig=fsconfig)
+    shlf = shelf.Shelf()
+    storage_options = {"auto_mkdir": True}
 
     data = {"a": 1, "b": 2}
 
-    s.put(data, "myobj")
-    data2 = s.get("myobj", dict)
+    shlf.put(data, f"file://{tmp_path}/myobj", storage_options=storage_options)
+    datanew = shlf.get(f"file://{tmp_path}/myobj", dict, storage_options=storage_options)
 
-    assert data == data2
+    assert data == datanew


### PR DESCRIPTION
Some things are not fleshed out yet, e.g. the treatment of files and filenames in the deserializer context.

Unifies the interface in the serde interface, whereby filenames need not be returned anymore.

Instead of an exit stack, the shelf's tempdir is managed by the class, including a weakref finalizer cleaning up the directory.